### PR TITLE
feat: add private Cloudflare cloud sync for cross-device preset editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,51 @@ Use the bundled batch script to automate the local setup:
 3. The script installs dependencies when needed and starts the Vite development server.
 4. Open [http://localhost:5173](http://localhost:5173) in your browser, and press `Ctrl+C` in the terminal to stop the server when finished.
 
+## 🔐 Private cloud sync (Cloudflare)
+
+By default the editor stores everything in the browser's `localStorage`, which is
+**per-device** — your phone and PC would each keep a separate library. This fork
+adds an optional **Cloudflare** backend so your presets live in one central place
+and stay in sync across devices, gated so **only you** can reach them.
+
+### How it works
+
+```
+Cloudflare Access (only your email can log in)
+  └─ Cloudflare Pages  (https://<project>.pages.dev)
+       ├─ static Vue app  (the built dist/)
+       └─ /api/presets  GET/PUT  ◄──►  Cloudflare KV  (your presets)
+```
+
+- `wrangler.toml` — Pages project config + KV binding.
+- `functions/api/presets.js` — the GET/PUT API backed by KV.
+- `src/stores/cloudSync.js` — pulls on load, pushes on change (localStorage stays
+  as an offline cache). If the API is unreachable the app silently runs local-only,
+  so `npm run dev` is unaffected.
+
+The toolbar shows a small dot: green = synced, amber = syncing, red = error,
+grey = local only.
+
+### Setup (one time, ~15 minutes)
+
+1. **Create a free Cloudflare account** at <https://dash.cloudflare.com/sign-up>.
+2. **Deploy with Pages** → *Workers & Pages* → *Create* → *Pages* → *Connect to Git*,
+   pick this repo. Build command `npm run build`, output directory `dist`. Name the
+   project `stpreseteditor` (matching `wrangler.toml`). First deploy gives you a
+   `https://<project>.pages.dev` URL.
+3. **Create the KV store**: run `npx wrangler kv namespace create PRESETS` and copy
+   the printed `id`. Uncomment the `[[kv_namespaces]]` block in `wrangler.toml`,
+   paste the `id`, commit and push — Pages redeploys automatically.
+   _(Or add it in the dashboard: project → Settings → Functions → KV bindings →
+   variable `PRESETS`.)_
+4. **Lock it down with Cloudflare Access**: *Zero Trust* → *Access* → *Applications*
+   → add a **Self-hosted** app for your `<project>.pages.dev` hostname, then add a
+   policy **Allow → Emails → your address only**. Everyone else is blocked at the
+   edge before the app loads, and the API receives your verified identity.
+
+> **Privacy note:** the app is fully open until step 4 is complete. Enable Access
+> before importing anything you want kept private.
+
 ## 📄 License
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/functions/api/presets.js
+++ b/functions/api/presets.js
@@ -1,0 +1,66 @@
+// Cloudflare Pages Function — mounted automatically at  /api/presets
+//
+// GET  -> returns your stored preset library document: { updatedAt, data }
+// PUT  -> overwrites it with the request body (same shape)
+//
+// SECURITY MODEL
+// --------------
+// The real lock is Cloudflare Access (Phase 4): once enabled on this Pages
+// project, Cloudflare blocks every unauthenticated request at the edge before
+// it ever reaches this code, and injects a trusted, un-spoofable header naming
+// the signed-in user. We use that header to scope storage per-identity, so even
+// the data is partitioned to you. Before Access is turned on the app is open —
+// enable Access to make it truly private.
+
+const FALLBACK_KEY = 'library';
+
+/** Build the KV key for the authenticated user (per-identity isolation). */
+function keyForRequest(request) {
+  // Cloudflare Access sets this header; clients cannot forge it through Access.
+  const email = request.headers.get('Cf-Access-Authenticated-User-Email');
+  return email ? `library:${email}` : FALLBACK_KEY;
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+}
+
+export async function onRequestGet({ env, request }) {
+  if (!env.PRESETS) {
+    // KV not bound yet — tell the client so it falls back to local-only.
+    return json({ error: 'kv_not_configured' }, 503);
+  }
+
+  const stored = await env.PRESETS.get(keyForRequest(request));
+  if (!stored) {
+    return json({ updatedAt: null, data: null });
+  }
+  return new Response(stored, {
+    headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+}
+
+export async function onRequestPut({ env, request }) {
+  if (!env.PRESETS) {
+    return json({ error: 'kv_not_configured' }, 503);
+  }
+
+  const raw = await request.text();
+
+  // Validate shape before persisting so we never store corrupt data.
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return json({ error: 'invalid_json' }, 400);
+  }
+  if (typeof parsed !== 'object' || parsed === null || !('updatedAt' in parsed)) {
+    return json({ error: 'invalid_shape' }, 400);
+  }
+
+  await env.PRESETS.put(keyForRequest(request), raw);
+  return json({ ok: true, updatedAt: parsed.updatedAt });
+}

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -9,10 +9,28 @@ import {
     EllipsisVerticalIcon,
     InformationCircleIcon,
 } from '@heroicons/vue/24/outline';
+import { computed } from 'vue';
 import { usePresetStore } from '../stores/presetStore';
+import { useSyncStore } from '../stores/syncStore';
 
 // Initialize the preset store
 const store = usePresetStore();
+
+// Cloud sync status (Cloudflare KV) for the indicator
+const sync = useSyncStore();
+const syncDotClass = computed(() => {
+  if (!sync.cloudEnabled) return 'bg-gray-300';
+  switch (sync.status) {
+    case 'synced':
+      return 'bg-green-500';
+    case 'syncing':
+      return 'bg-amber-400 animate-pulse';
+    case 'error':
+      return 'bg-red-500';
+    default:
+      return 'bg-gray-300';
+  }
+});
 
 // Reset & Language now live in Settings modal
 </script>
@@ -36,6 +54,14 @@ const store = usePresetStore();
 
     <!-- Desktop: Action Buttons Group -->
     <div class="hidden items-center space-x-3 md:flex">
+      <!-- Cloud sync status indicator -->
+      <div
+        class="flex items-center gap-1.5 text-xs text-gray-500"
+        :title="sync.statusLabel"
+      >
+        <span class="inline-block h-2 w-2 rounded-full" :class="syncDotClass"></span>
+        <span class="hidden lg:inline">{{ sync.statusLabel }}</span>
+      </div>
       <!-- Language moved to Settings -->
       <!-- Import JSON Button -->
       <button
@@ -74,6 +100,12 @@ const store = usePresetStore();
 
     <!-- Mobile: Action Group with Right Sidebar Toggle and Menu -->
     <div class="flex items-center md:hidden">
+      <!-- Cloud sync status dot -->
+      <span
+        class="mr-1 inline-block h-2 w-2 rounded-full"
+        :class="syncDotClass"
+        :title="sync.statusLabel"
+      ></span>
       <!-- Right Sidebar Toggle Button -->
       <button class="p-2" @click="store.toggleRightSidebar()">
         <InformationCircleIcon class="h-6 w-6" />

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { createPinia } from 'pinia';
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate';
 import { createApp } from 'vue';
 import App from './App.vue';
+import { initCloudSync } from './stores/cloudSync';
 import './style.css';
 
 // Create Vue application instance
@@ -21,3 +22,7 @@ app.use(FloatingVue); // Tooltip and popover functionality
 
 // Mount the application to the DOM
 app.mount('#app');
+
+// Start cloud sync (Cloudflare KV) after mount so the store has restored from
+// its local cache first. No-ops gracefully to local-only if the API is absent.
+initCloudSync();

--- a/src/stores/cloudSync.js
+++ b/src/stores/cloudSync.js
@@ -1,0 +1,117 @@
+import { debounce } from 'lodash-es';
+import { usePresetStore } from './presetStore';
+import { useSyncStore } from './syncStore';
+
+// The Pages Function endpoint (same origin as the app).
+const API_URL = '/api/presets';
+// Coalesce rapid edits (typing, dragging) into one upload.
+const PUSH_DEBOUNCE_MS = 1500;
+
+// Guards data->cloud echoes while we apply a cloud snapshot locally.
+let suppressPush = false;
+// JSON of the snapshot currently mirrored in the cloud; used to skip no-op pushes.
+let syncedSerialized = null;
+
+/**
+ * GET the cloud document.
+ * @returns {Promise<{updatedAt: string|null, data: object|null}|null>}
+ *   The document, or null when the cloud is unavailable (so we stay local-only).
+ */
+async function fetchCloudDocument() {
+  try {
+    const res = await fetch(API_URL, { headers: { accept: 'application/json' } });
+    if (!res.ok) return null; // 503 (KV not configured), 404, 5xx -> local-only
+    const doc = await res.json();
+    return doc && typeof doc === 'object' ? doc : null;
+  } catch {
+    return null; // offline / network error
+  }
+}
+
+/**
+ * PUT a snapshot to the cloud.
+ * @returns {Promise<boolean>} true on success
+ */
+async function pushCloudDocument(payload) {
+  try {
+    const res = await fetch(API_URL, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Upload the current local snapshot (no-op if it already matches the cloud).
+ */
+async function pushNow(preset, sync) {
+  const snapshot = preset.buildSyncSnapshot();
+  const serialized = JSON.stringify(snapshot);
+
+  if (serialized === syncedSerialized) {
+    sync.set({ pendingSync: false, status: 'synced' });
+    return;
+  }
+
+  sync.set({ status: 'syncing' });
+  const updatedAt = new Date().toISOString();
+  const ok = await pushCloudDocument({ updatedAt, data: snapshot });
+
+  if (ok) {
+    syncedSerialized = serialized;
+    sync.set({ status: 'synced', lastSyncedAt: updatedAt, pendingSync: false });
+  } else {
+    sync.set({ status: 'error', pendingSync: true });
+  }
+}
+
+/**
+ * Initialise cloud sync: reconcile local <-> cloud once, then push on every
+ * subsequent data change. Safe no-op (local-only) when the API is unreachable,
+ * so `npm run dev` and pre-KV deploys keep working unchanged.
+ */
+export async function initCloudSync() {
+  const preset = usePresetStore();
+  const sync = useSyncStore();
+
+  const doc = await fetchCloudDocument();
+  if (!doc) {
+    sync.set({ cloudEnabled: false, status: 'offline' });
+    return; // local-only; no subscription needed
+  }
+  sync.set({ cloudEnabled: true });
+
+  const cloudHasData = doc.data && typeof doc.data === 'object';
+  const cloudIsNewer = cloudHasData && doc.updatedAt && doc.updatedAt !== sync.lastSyncedAt;
+
+  if (!cloudHasData) {
+    // Cloud is empty -> seed it from this device.
+    await pushNow(preset, sync);
+  } else if (cloudIsNewer && !sync.pendingSync) {
+    // Adopt the newer cloud copy (no un-pushed local edits to protect).
+    suppressPush = true;
+    preset.applyCloudData(doc.data);
+    suppressPush = false;
+    syncedSerialized = JSON.stringify(preset.buildSyncSnapshot());
+    sync.set({ status: 'synced', lastSyncedAt: doc.updatedAt, pendingSync: false });
+  } else if (sync.pendingSync || cloudIsNewer) {
+    // Local is authoritative: flush offline edits (they win over a remote change).
+    await pushNow(preset, sync);
+  } else {
+    // Already in sync with the cloud.
+    syncedSerialized = JSON.stringify(preset.buildSyncSnapshot());
+    sync.set({ status: 'synced' });
+  }
+
+  // Push (debounced) whenever the portable data changes from here on.
+  const debouncedPush = debounce(() => pushNow(preset, sync), PUSH_DEBOUNCE_MS);
+  preset.$subscribe(() => {
+    if (suppressPush || !sync.cloudEnabled) return;
+    if (!sync.pendingSync) sync.set({ pendingSync: true });
+    debouncedPush();
+  });
+}

--- a/src/stores/presetStore.js
+++ b/src/stores/presetStore.js
@@ -3,6 +3,25 @@ import { defineStore } from 'pinia';
 import languageData from '../assets/languages.json';
 
 /**
+ * The state paths that make up a user's portable data and are synced to the
+ * cloud (Cloudflare KV) so the same library is available on every device.
+ * UI-only and derived state are intentionally excluded.
+ */
+export const SYNC_DATA_PATHS = [
+  'rawJson',
+  'originalFilename',
+  'prompts',
+  'promptOrder',
+  'macroDisplayMode',
+  'currentLanguage',
+  'promptCollapseStates',
+  'skipDeleteConfirmation',
+  'savedPresets',
+  'currentPresetId',
+  'defaultPresetId',
+];
+
+/**
  * @typedef {object} MacroData
  * @property {string} id - A unique identifier for this specific macro instance, e.g., "promptId-charIndex".
  * @property {string} full - The full, original macro string, e.g., "{{setvar::x::10}}".
@@ -1819,6 +1838,32 @@ export const usePresetStore = defineStore('preset', {
       this.batchReplaceHistory.push(entry);
       const distinctPrompts = new Set(entry.changes.map((c) => c.promptId)).size;
       return { prompts: distinctPrompts };
+    },
+
+    // --- Cloud sync helpers (used by stores/cloudSync.js) ---
+
+    /**
+     * Build a plain snapshot of just the portable data paths for upload.
+     * @returns {Object} snapshot keyed by SYNC_DATA_PATHS
+     */
+    buildSyncSnapshot() {
+      const snapshot = {};
+      SYNC_DATA_PATHS.forEach((key) => {
+        snapshot[key] = this[key];
+      });
+      return snapshot;
+    },
+
+    /**
+     * Replace local data with a snapshot pulled from the cloud, then re-analyze.
+     * @param {Object} data - snapshot previously produced by buildSyncSnapshot
+     */
+    applyCloudData(data) {
+      if (!data || typeof data !== 'object') return;
+      SYNC_DATA_PATHS.forEach((key) => {
+        if (key in data) this[key] = data[key];
+      });
+      this.analyzeAllMacros();
     },
   },
   persist: {

--- a/src/stores/syncStore.js
+++ b/src/stores/syncStore.js
@@ -1,0 +1,48 @@
+import { defineStore } from 'pinia';
+
+/**
+ * Holds cloud-sync status only. Kept separate from the data store so that
+ * status updates (syncing/synced/etc.) never look like editable-data changes
+ * to the data store's change subscription — which would cause sync loops.
+ *
+ * `lastSyncedAt` and `pendingSync` are persisted so that edits made while
+ * offline are still recognised (and flushed) after a reload.
+ */
+export const useSyncStore = defineStore('sync', {
+  state: () => ({
+    cloudEnabled: false, // Whether the cloud API is reachable/configured
+    status: 'idle', // 'idle' | 'syncing' | 'synced' | 'offline' | 'error'
+    lastSyncedAt: null, // ISO timestamp of the cloud document we last reconciled with
+    pendingSync: false, // True when local has edits not yet pushed to the cloud
+  }),
+  getters: {
+    /** Human-friendly label for a status indicator. */
+    statusLabel: (state) => {
+      if (!state.cloudEnabled) return 'Local only';
+      switch (state.status) {
+        case 'syncing':
+          return 'Syncing…';
+        case 'synced':
+          return 'Synced';
+        case 'error':
+          return 'Sync error';
+        case 'offline':
+          return 'Offline';
+        default:
+          return 'Idle';
+      }
+    },
+  },
+  actions: {
+    set(meta) {
+      if (!meta) return;
+      if ('cloudEnabled' in meta) this.cloudEnabled = meta.cloudEnabled;
+      if ('status' in meta) this.status = meta.status;
+      if ('lastSyncedAt' in meta) this.lastSyncedAt = meta.lastSyncedAt;
+      if ('pendingSync' in meta) this.pendingSync = meta.pendingSync;
+    },
+  },
+  persist: {
+    paths: ['lastSyncedAt', 'pendingSync'],
+  },
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,24 @@
+# Cloudflare Pages configuration for STPresetEditor.
+#
+# This file lets Cloudflare Pages serve the built Vue app (from ./dist) AND run
+# the API in ./functions, all from one project. See README "Cloudflare setup".
+
+name = "stpreseteditor"
+compatibility_date = "2025-01-01"
+
+# The folder Vite outputs to (`npm run build`). Pages serves these static files.
+pages_build_output_dir = "dist"
+
+# --- KV storage (Phase 2) ---
+# Your presets are stored centrally in a Cloudflare KV namespace so they sync
+# across mobile and PC. Until you create the namespace and paste its id below,
+# the app still runs — it just falls back to per-device local storage.
+#
+# To enable cloud sync:
+#   1. Run:  npx wrangler kv namespace create PRESETS
+#   2. Uncomment the three lines below and paste the printed id.
+#   3. Commit + push (Git-connected Pages redeploys automatically).
+#
+# [[kv_namespaces]]
+# binding = "PRESETS"
+# id = "PASTE_YOUR_KV_NAMESPACE_ID_HERE"


### PR DESCRIPTION
Adds an optional Cloudflare Pages backend so presets sync across mobile and PC instead of living in per-device localStorage:

- wrangler.toml: Pages config with commented KV binding
- functions/api/presets.js: GET/PUT API backed by Cloudflare KV, scoped per Access-authenticated identity
- src/stores/syncStore.js: dedicated sync-status store (kept out of the data store's change subscription to avoid sync loops)
- src/stores/cloudSync.js: reconciles local<->cloud on load, debounced push on change, graceful local-only fallback when the API is absent
- presetStore: buildSyncSnapshot/applyCloudData helpers + SYNC_DATA_PATHS
- AppToolbar: sync status indicator
- README: Cloudflare Pages + KV + Access setup walkthrough